### PR TITLE
Update references to ejholmes/restforce to restforcegem/restforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 * Raise an error where a custom external ID field name is supplied to `upsert` and `upsert!`, but it is missing from the provided attributes (@velveret)
 * Use the Restforce client's configured SSL options for authentication requests (@jvdp)
-* Fix bug where `upsert` and `upsert!` mutate the provided attributes, previously fixed in [v1.5.3](https://github.com/ejholmes/restforce/blob/master/CHANGELOG.md#153-jun-26-2015) (@velveret)
+* Fix bug where `upsert` and `upsert!` mutate the provided attributes, previously fixed in [v1.5.3](https://github.com/restforcegem/restforce/blob/master/CHANGELOG.md#153-jun-26-2015) (@velveret)
 
 
 ## 2.5.2 (Apr 3, 2017)
 
 * Ensure `Restforce::Middleware::Logger` is the last Faraday middleware to be called so everything is properly logged (including the effects of the `Gzip` and `CustomHeaders` middlewares which were previously running after it) (@jonnymacs)
-* Suppress [Hashie](https://github.com/intridea/hashie) warnings when using Hashie v3.5.0 or later (see [#295](https://github.com/ejholmes/restforce/pull/295) for details) (@janraasch)
+* Suppress [Hashie](https://github.com/intridea/hashie) warnings when using Hashie v3.5.0 or later (see [#295](https://github.com/restforcegem/restforce/pull/295) for details) (@janraasch)
 
 ## 2.5.1 (Mar 16, 2017)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
 We love pull requests from everyone. By participating in this project, you
-agree to abide by our [code of conduct](https://github.com/ejholmes/restforce/blob/master/CODE_OF_CONDUCT.md).
+agree to abide by our [code of conduct](https://github.com/restforcegem/restforce/blob/master/CODE_OF_CONDUCT.md).
 
 Fork, then clone the repo:
 
-    git clone git@github.com:ejholmes/restforce.git
+    git clone git@github.com:restforcegem/restforce.git
 
 Set up your machine:
 
@@ -23,7 +23,7 @@ Make your change. Add tests for your change. Make the tests pass:
 
     script/test
 
-Push to your fork and [submit a pull request](https://github.com/ejholmes/restforce/compare/).
+Push to your fork and [submit a pull request](https://github.com/restforcegem/restforce/compare/).
 
 At this point you're waiting on us. We like to at least comment on pull requests
 within a few days. We may suggest

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Eric J. Holmes
+Copyright (c) 2017 Eric J. Holmes and Tim Rogers
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Restforce
 
-[![travis-ci](https://travis-ci.org/ejholmes/restforce.png?branch=master)](https://travis-ci.org/ejholmes/restforce) [![Code Climate](https://codeclimate.com/github/ejholmes/restforce.png)](https://codeclimate.com/github/ejholmes/restforce) [![Dependency Status](https://gemnasium.com/ejholmes/restforce.png)](https://gemnasium.com/ejholmes/restforce)
+[![CircleCI](https://circleci.com/gh/restforcegem/restforce.svg?style=svg)](https://circleci.com/gh/restforcegem/restforce) [![Code Climate](https://codeclimate.com/github/ejholmes/restforce.png)](https://codeclimate.com/github/ejholmes/restforce) [![Dependency Status](https://gemnasium.com/ejholmes/restforce.png)](https://gemnasium.com/ejholmes/restforce)
 ![](https://img.shields.io/gem/dt/restforce.svg)
 
 Restforce is a ruby gem for the [Salesforce REST api](http://www.salesforce.com/us/developer/docs/api_rest/index.htm).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Restforce
 
-[![CircleCI](https://circleci.com/gh/restforcegem/restforce.svg?style=svg)](https://circleci.com/gh/restforcegem/restforce) [![Code Climate](https://codeclimate.com/github/ejholmes/restforce.png)](https://codeclimate.com/github/ejholmes/restforce) [![Dependency Status](https://gemnasium.com/ejholmes/restforce.png)](https://gemnasium.com/ejholmes/restforce)
+[![CircleCI](https://circleci.com/gh/restforcegem/restforce.svg?style=svg)](https://circleci.com/gh/restforcegem/restforce) [![Code Climate](https://codeclimate.com/github/restforcegem/restforce.png)](https://codeclimate.com/github/restforcegem/restforce) [![Dependency Status](https://gemnasium.com/restforcegem/restforce.png)](https://gemnasium.com/restforcegem/restforce)
 ![](https://img.shields.io/gem/dt/restforce.svg)
 
 Restforce is a ruby gem for the [Salesforce REST api](http://www.salesforce.com/us/developer/docs/api_rest/index.htm).
@@ -19,7 +19,7 @@ Features include:
 * Support for dependent picklists.
 * Support for decoding [Force.com Canvas](http://www.salesforce.com/us/developer/docs/platform_connectpre/canvas_framework.pdf) signed requests. (NEW!)
 
-[Official Website](http://restforce.org/) | [Documentation](http://rubydoc.info/gems/restforce/frames) | [Changelog](https://github.com/ejholmes/restforce/tree/master/CHANGELOG.md)
+[Official Website](http://restforce.org/) | [Documentation](http://rubydoc.info/gems/restforce/frames) | [Changelog](https://github.com/restforcegem/restforce/tree/master/CHANGELOG.md)
 
 ## Installation
 
@@ -35,11 +35,11 @@ Or install it yourself as:
 
     $ gem install restforce
 
-__As of [version 2.5.0](https://github.com/ejholmes/restforce/blob/master/CHANGELOG.md#250-dec-5-2016), this gem is only compatible with Ruby 2.0.0 and later.__ To use Ruby 1.9.3, you'll need to manually specify that you wish to use version 2.4.2, or 1.5.3 for Ruby 1.9.2 support.
+__As of [version 2.5.0](https://github.com/restforcegem/restforce/blob/master/CHANGELOG.md#250-dec-5-2016), this gem is only compatible with Ruby 2.0.0 and later.__ To use Ruby 1.9.3, you'll need to manually specify that you wish to use version 2.4.2, or 1.5.3 for Ruby 1.9.2 support.
 
 The library is only tested with Ruby 2.2.0 onwards. It may work with Ruby 2.0 and Ruby 2.1, but this is not guaranteed.
 
-This gem is versioned using [Semantic Versioning](http://semver.org/), so you can be confident when updating that there will not be breaking changes outside of a major version (following format MAJOR.MINOR.PATCH, so for instance moving from 2.3.0 to 3.0.0 would be allowed to include incompatible API changes). See the [changelog](https://github.com/ejholmes/restforce/tree/master/CHANGELOG.md) for details on what has changed in each version.
+This gem is versioned using [Semantic Versioning](http://semver.org/), so you can be confident when updating that there will not be breaking changes outside of a major version (following format MAJOR.MINOR.PATCH, so for instance moving from 2.3.0 to 3.0.0 would be allowed to include incompatible API changes). See the [changelog](https://github.com/restforcegem/restforce/tree/master/CHANGELOG.md) for details on what has changed in each version.
 
 ## Usage
 
@@ -477,7 +477,7 @@ File.open(document.Name, 'wb') { |f| f.write(document.Body) }
 
 **Note:** The example above is only applicable if your SOQL query returns a single Document record. If more than one record is returned, 
 the Body field contains an URL to retrieve the BLOB content for the first 2000 records returned. Subsequent records contain the BLOB content
-in the Body field. This is confusing and hard to debug. See notes in [Issue #301](https://github.com/ejholmes/restforce/issues/301#issuecomment-298972959) explaining this detail. 
+in the Body field. This is confusing and hard to debug. See notes in [Issue #301](https://github.com/restforcegem/restforce/issues/301#issuecomment-298972959) explaining this detail. 
 **Executive Summary:** Don't retrieve the Body field in a SOQL query; instead, use the BLOB retrieval URL documented 
 in [SObject BLOB Retrieve](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_blob_retrieve.htm) 
 
@@ -653,7 +653,7 @@ Callbacks.
 
 We welcome all contributions - they help us make Restforce the best gem possible.
 
-See our [CONTRIBUTING.md](https://github.com/ejholmes/restforce/blob/master/CONTRIBUTING.md) file for help with getting set up to work on the project locally.
+See our [CONTRIBUTING.md](https://github.com/restforcegem/restforce/blob/master/CONTRIBUTING.md) file for help with getting set up to work on the project locally.
 
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.version       = Restforce::VERSION
 
   gem.metadata = {
-    'source_code_uri' => 'https://github.com/ejholmes/restforce',
-    'changelog_uri'   => 'https://github.com/ejholmes/restforce/blob/master/CHANGELOG.md'
+    'source_code_uri' => 'https://github.com/restforcegem/restforce',
+    'changelog_uri'   => 'https://github.com/restforcegem/restforce/blob/master/CHANGELOG.md'
   }
 
   gem.required_ruby_version = '>= 2.0'

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["eric@ejholmes.net", "tim@gocardless.com"]
   gem.description   = %q{A lightweight ruby client for the Salesforce REST API.}
   gem.summary       = %q{A lightweight ruby client for the Salesforce REST API.}
-  gem.homepage      = "http://restforce.org/"
+  gem.homepage      = "https://restforce.org/"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
This PR also:
* Changes the TravisCI badge in the README to a CircleCI badge
* Updates the copyright notice to say 2012 instead of 2017, and include my name
* Fixes the website URL in the .gemspec, which should be HTTPS